### PR TITLE
Add folder reference manual

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -1,0 +1,40 @@
+# Docs Folder Overview 📚
+
+## Folder Purpose 🎯
+Stores architecture diagrams and reference documentation for contributors.
+
+## Full Directory Tree
+```text
+docs/
+  ├── architecture.png
+  ├── docs.md
+  ├── frontend.md
+  ├── libs.md
+  └── services.md
+```
+
+## Item-by-Item Table
+| Path | Role |
+| --- | --- |
+| architecture.png | System architecture diagram used in the README. |
+| docs.md | This file. Overview of the `docs` directory. |
+| frontend.md | Reference manual for the `frontend` folder. |
+| libs.md | Reference manual for the `libs` folder. |
+| services.md | Reference manual for the `services` folder. |
+
+## Key Workflows / Entry Points
+- Diagrams are included in the README via Markdown image links.
+- Additional markdown docs may be added for architectural or API specs.
+
+## Example Usage
+```bash
+# Open the main diagram (on macOS)
+open docs/architecture.png
+```
+
+## Development Tips
+- Keep diagrams in sync with code changes.
+- Prefer lightweight PNG/SVG formats for images.
+
+## TODO
+- TODO: add more design documents and workflow guides.

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -1,0 +1,72 @@
+# Frontend Folder Overview 💻
+
+## Folder Purpose 🎯
+Next.js 14 application providing the user interface for PathLight.
+
+## Full Directory Tree
+```text
+frontend/
+  ├── .gitignore
+  ├── README.md
+  ├── eslint.config.mjs
+  ├── next.config.ts
+  ├── package-lock.json
+  ├── package.json
+  ├── postcss.config.mjs
+  ├── public/
+  │   ├── file.svg
+  │   ├── globe.svg
+  │   ├── next.svg
+  │   ├── vercel.svg
+  │   └── window.svg
+  ├── src/
+  │   └── app/
+  │       ├── favicon.ico
+  │       ├── globals.css
+  │       ├── layout.tsx
+  │       └── page.tsx
+  └── tsconfig.json
+```
+
+## Item-by-Item Table
+| Path | Role |
+| --- | --- |
+| .gitignore | Ignore patterns for Node-related files. |
+| README.md | Instructions for running the Next.js app. |
+| eslint.config.mjs | ESLint rules used during linting. |
+| next.config.ts | Next.js configuration and plugins. |
+| package-lock.json | Exact dependency versions for npm. |
+| package.json | Declares dependencies and scripts. |
+| postcss.config.mjs | Tailwind/PostCSS configuration. |
+| public/ | Static assets served directly. |
+| public/file.svg | SVG icon asset. |
+| public/globe.svg | SVG icon asset. |
+| public/next.svg | SVG icon asset. |
+| public/vercel.svg | SVG icon asset. |
+| public/window.svg | SVG icon asset. |
+| src/ | Application source code. |
+| src/app | Next.js app directory. |
+| src/app/favicon.ico | Browser favicon. |
+| src/app/globals.css | Global CSS styles. |
+| src/app/layout.tsx | Root layout component. |
+| src/app/page.tsx | Home page component. |
+| tsconfig.json | TypeScript compiler options. |
+
+## Key Workflows / Entry Points
+- `npm run dev` launches the development server on port 3000.
+- `npm run build` creates an optimized production build.
+- `npx next lint` checks code quality using ESLint.
+
+## Example Usage
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+## Development Tips
+- Ensure Node 18+ is installed for compatibility.
+- Tailwind styles live in `globals.css` and the `postcss` config.
+
+## TODO
+- TODO: add unit tests and more pages.

--- a/docs/libs.md
+++ b/docs/libs.md
@@ -1,0 +1,83 @@
+# Libs Folder Overview 📦
+
+## Folder Purpose 🎯
+Shared Python and TypeScript packages used by the services and frontend.
+
+## Full Directory Tree
+```text
+libs/
+  ├── ai-prompts/
+  │   ├── README.md
+  │   ├── pyproject.toml
+  │   └── prompts/
+  │       └── __init__.py
+  ├── common-types-py/
+  │   ├── README.md
+  │   └── pyproject.toml
+  ├── common-types-ts/
+  │   ├── README.md
+  │   ├── package.json
+  │   ├── tsconfig.json
+  │   └── src/
+  │       └── index.ts
+  ├── common-utils-py/
+  │   ├── README.md
+  │   ├── pyproject.toml
+  │   └── utils/
+  │       ├── __init__.py
+  │       ├── logger.py
+  │       └── retry.py
+  └── common-utils-ts/
+      ├── README.md
+      ├── package.json
+      ├── tsconfig.json
+      └── src/
+          ├── logger.ts
+          └── retry.ts
+```
+
+## Item-by-Item Table
+| Path | Role |
+| --- | --- |
+| ai-prompts/ | Placeholder package for shared AI prompt templates. |
+| ai-prompts/README.md | (empty) documentation stub. |
+| ai-prompts/pyproject.toml | Python package configuration. |
+| ai-prompts/prompts/__init__.py | Package initializer. |
+| common-types-py/ | Python type stubs shared across services. |
+| common-types-py/README.md | (empty) documentation stub. |
+| common-types-py/pyproject.toml | Package metadata. |
+| common-types-ts/ | TypeScript type definitions. |
+| common-types-ts/README.md | (empty) documentation stub. |
+| common-types-ts/package.json | Node package metadata. |
+| common-types-ts/tsconfig.json | TS compiler options. |
+| common-types-ts/src/index.ts | Type definitions entry point. |
+| common-utils-py/ | Python helper utilities. |
+| common-utils-py/README.md | (empty) documentation stub. |
+| common-utils-py/pyproject.toml | Package configuration. |
+| common-utils-py/utils/__init__.py | Package initializer. |
+| common-utils-py/utils/logger.py | Logging helpers (empty). |
+| common-utils-py/utils/retry.py | Retry utilities (empty). |
+| common-utils-ts/ | TypeScript helper utilities. |
+| common-utils-ts/README.md | (empty) documentation stub. |
+| common-utils-ts/package.json | Node package metadata. |
+| common-utils-ts/tsconfig.json | TS compiler options. |
+| common-utils-ts/src/logger.ts | Logging helpers (empty). |
+| common-utils-ts/src/retry.ts | Retry utilities (empty). |
+
+## Key Workflows / Entry Points
+- Install Python libs locally with `pip install -e libs/common-utils-py`.
+- Use `npm install` inside TypeScript packages when developing.
+- Packages can be imported from services or the frontend.
+
+## Example Usage
+```bash
+# Example: install Python utilities in editable mode
+pip install -e libs/common-utils-py
+```
+
+## Development Tips
+- Keep TypeScript and Python types in sync when both exist.
+- Add unit tests before publishing libraries.
+
+## TODO
+- TODO: flesh out utility functions and type definitions.

--- a/docs/services.md
+++ b/docs/services.md
@@ -1,0 +1,132 @@
+# Services Folder Overview 🛠️
+
+## Folder Purpose 🎯
+Collection of FastAPI microservices that power the platform APIs.
+
+## Full Directory Tree
+```text
+services/
+  ├── api-gateway/
+  │   ├── Dockerfile
+  │   ├── requirements.txt
+  │   └── src/
+  │       └── .gitkeep
+  ├── auth-service/
+  │   ├── Dockerfile
+  │   ├── alembic.ini
+  │   ├── pyproject.toml
+  │   ├── alembic/
+  │   │   ├── README
+  │   │   ├── env.py
+  │   │   └── script.py.mako
+  │   └── src/
+  │       └── .gitkeep
+  ├── course-service/
+  │   ├── Dockerfile
+  │   ├── alembic.ini
+  │   ├── pyproject.toml
+  │   ├── alembic/
+  │   │   ├── README
+  │   │   ├── env.py
+  │   │   └── script.py.mako
+  │   └── src/
+  │       └── .gitkeep
+  ├── lesson-service/
+  │   ├── Dockerfile
+  │   ├── alembic.ini
+  │   ├── pyproject.toml
+  │   ├── alembic/
+  │   │   ├── README
+  │   │   ├── env.py
+  │   │   └── script.py.mako
+  │   └── src/
+  │       └── .gitkeep
+  ├── test-service/
+  │   ├── Dockerfile
+  │   ├── alembic.ini
+  │   ├── pyproject.toml
+  │   ├── alembic/
+  │   │   ├── README
+  │   │   ├── env.py
+  │   │   └── script.py.mako
+  │   └── src/
+  │       └── .gitkeep
+  └── user-service/
+      ├── Dockerfile
+      ├── alembic.ini
+      ├── pyproject.toml
+      ├── alembic/
+      │   ├── README
+      │   ├── env.py
+      │   └── script.py.mako
+      └── src/
+          └── .gitkeep
+```
+
+## Item-by-Item Table
+| Path | Role |
+| --- | --- |
+| api-gateway/ | Gateway routing requests to services. |
+| api-gateway/Dockerfile | Container build instructions. |
+| api-gateway/requirements.txt | Python dependencies for gateway. |
+| api-gateway/src/.gitkeep | Placeholder for gateway code. |
+| auth-service/ | Authentication microservice skeleton. |
+| auth-service/Dockerfile | Build file for auth service. |
+| auth-service/alembic.ini | Alembic configuration. |
+| auth-service/pyproject.toml | Python package metadata. |
+| auth-service/alembic/README | Alembic usage notes. |
+| auth-service/alembic/env.py | Migration environment. |
+| auth-service/alembic/script.py.mako | Migration template. |
+| auth-service/src/.gitkeep | Placeholder for service code. |
+| course-service/ | Course management microservice skeleton. |
+| course-service/Dockerfile | Build file for course service. |
+| course-service/alembic.ini | Alembic configuration. |
+| course-service/pyproject.toml | Python package metadata. |
+| course-service/alembic/README | Alembic usage notes. |
+| course-service/alembic/env.py | Migration environment. |
+| course-service/alembic/script.py.mako | Migration template. |
+| course-service/src/.gitkeep | Placeholder for service code. |
+| lesson-service/ | Lesson management microservice skeleton. |
+| lesson-service/Dockerfile | Build file for lesson service. |
+| lesson-service/alembic.ini | Alembic configuration. |
+| lesson-service/pyproject.toml | Python package metadata. |
+| lesson-service/alembic/README | Alembic usage notes. |
+| lesson-service/alembic/env.py | Migration environment. |
+| lesson-service/alembic/script.py.mako | Migration template. |
+| lesson-service/src/.gitkeep | Placeholder for service code. |
+| test-service/ | Testing microservice skeleton. |
+| test-service/Dockerfile | Build file for test service. |
+| test-service/alembic.ini | Alembic configuration. |
+| test-service/pyproject.toml | Python package metadata. |
+| test-service/alembic/README | Alembic usage notes. |
+| test-service/alembic/env.py | Migration environment. |
+| test-service/alembic/script.py.mako | Migration template. |
+| test-service/src/.gitkeep | Placeholder for service code. |
+| user-service/ | User management microservice skeleton. |
+| user-service/Dockerfile | Build file for user service. |
+| user-service/alembic.ini | Alembic configuration. |
+| user-service/pyproject.toml | Python package metadata. |
+| user-service/alembic/README | Alembic usage notes. |
+| user-service/alembic/env.py | Migration environment. |
+| user-service/alembic/script.py.mako | Migration template. |
+| user-service/src/.gitkeep | Placeholder for service code. |
+
+## Key Workflows / Entry Points
+- Build each service with `docker build -t <name> services/<service>`.
+- Run database migrations via `alembic upgrade head` inside a service dir.
+- Services will eventually expose FastAPI apps run with Uvicorn.
+
+## Example Usage
+```bash
+# Build the user service container
+cd services/user-service
+docker build -t user-service .
+```
+
+## Development Tips
+- Python 3.12 is expected for service code.
+- Use Alembic for schema migrations.
+- Implement FastAPI apps under each `src` directory.
+
+## TODO
+- TODO: flesh out service implementations and add tests.


### PR DESCRIPTION
## Summary
- create reference markdown docs for docs, frontend, libs and services folders

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68517b6be2c8832f8a1201e6daf2fd6f